### PR TITLE
Upload product images

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -82,7 +82,7 @@ class ProductsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def product_params
-      params.require(:product).permit(:title, :description, :image_file_name, :price)
+      params.require(:product).permit(:title, :description, :image, :price)
     end
 
     def invalid_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,6 +4,10 @@ class Product < ActiveRecord::Base
 
   before_destroy :ensure_not_referenced_by_any_line_item
 
+  has_attached_file :image, styles: {thumb: '200X200#'}
+  validates_attachment_content_type :image, content_type: /\Aimage/
+
+
   validates :title, :description, presence: true #image_url removed
   validates :price, numericality: {greater_than_or_equal_to: 0.01}
   validates :title, uniqueness: true, length: { minimum: 10 }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,13 +4,18 @@ class Product < ActiveRecord::Base
 
   before_destroy :ensure_not_referenced_by_any_line_item
 
-  validates :title, :description, presence: true #image_file_name removed
+  validates :title, :description, presence: true #image_url removed
   validates :price, numericality: {greater_than_or_equal_to: 0.01}
   validates :title, uniqueness: true, length: { minimum: 10 }
-  # validates :image_file_name, allow_blank: true, format: {
+  # validates :image_url, allow_blank: true, format: {
   #   with: %r{\.(gif|jpg|png)\Z}i,
   #   message: 'must be a URL for GIF, JPG or PNG image.'
   # }
+
+# Paperclip validations available
+# validates :avatar, :attachment_presence => true
+# validates_with AttachmentPresenceValidator, :attributes => :avatar
+# validates_with AttachmentSizeValidator, :attributes => :avatar, :less_than => 1.megabytes
 
   def self.latest
     Product.order(:updated_at).last

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@product) do |f| %>
+<%= form_for @product, html: {multipart: true} do |f| %>
   <% if @product.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@product.errors.count, "error") %> prohibited this product from being saved:</h2>
@@ -20,8 +20,8 @@
     <%= f.text_area :description, rows: 6 %>
   </div>
   <div class="field">
-    <%= f.label :image_file_name %><br>
-    <%= f.text_field :image_file_name %>
+    <%= f.label :image %><br>
+    <%= f.file_field :image %>
   </div>
   <div class="field">
     <%= f.label :price %><br>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -4,7 +4,7 @@
 <% @products.each do |product| %>
   <tr class="<%= cycle('list_line_odd', 'list_line_even') %>">
     <td>
-      <%= image_tag(product.image_file_name, class: 'list_image') %>
+      <%= image_tag product.image.url(:thumb) %>
     </td>
     <td class="list_description">
       <dl>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -11,8 +11,7 @@
 </p>
 
 <p>
-  <strong>Image url:</strong>
-  <%= @product.image_file_name %>
+  <%= image_tag @product.image.url(:thumb) %>
 </p>
 
 <p>

--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -12,7 +12,7 @@
   <% @products.each do |product| %>
     <% cache ['entry', product] do %>
       <div class="entry">
-        <%= image_tag(product.image_file_name) %>
+        <%= image_tag product.image.url(:thumb) %>
         <h3><%= product.title %></h3>
         <%= sanitize(product.description) %>
         <div class="price_line">


### PR DESCRIPTION
Added the ability to upload images using product edit form! Should display properly on individual product page, products index, and home index. 

Does not include image for seeded data. That's why seeded data have "images" show up as broken links. If we wanted to add this ability, further investigation and a a new open issue would be required.