### PR TITLE
Let products be downloadable

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -82,7 +82,7 @@ class ProductsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def product_params
-      params.require(:product).permit(:title, :description, :image_file_name, :price)
+      params.require(:product).permit(:title, :description, :image_file_name, :price, :pdf)
     end
 
     def invalid_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,9 +1,11 @@
 class Product < ActiveRecord::Base
   has_many :line_items, dependent: :destroy
   has_many :orders, through: :line_items
-
+  has_attached_file :pdf
+  
   before_destroy :ensure_not_referenced_by_any_line_item
 
+  validates_attachment_content_type :pdf, content_type: 'application/pdf'
   validates :title, :description, presence: true #image_url removed
   validates :price, numericality: {greater_than_or_equal_to: 0.01}
   validates :title, uniqueness: true, length: { minimum: 10 }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,13 +4,18 @@ class Product < ActiveRecord::Base
 
   before_destroy :ensure_not_referenced_by_any_line_item
 
-  validates :title, :description, presence: true #image_file_name removed
+  validates :title, :description, presence: true #image_url removed
   validates :price, numericality: {greater_than_or_equal_to: 0.01}
   validates :title, uniqueness: true, length: { minimum: 10 }
-  # validates :image_file_name, allow_blank: true, format: {
+  # validates :image_url, allow_blank: true, format: {
   #   with: %r{\.(gif|jpg|png)\Z}i,
   #   message: 'must be a URL for GIF, JPG or PNG image.'
   # }
+
+# Paperclip validations available
+# validates :avatar, :attachment_presence => true
+# validates_with AttachmentPresenceValidator, :attributes => :avatar
+# validates_with AttachmentSizeValidator, :attributes => :avatar, :less_than => 1.megabytes
 
   def self.latest
     Product.order(:updated_at).last

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@product) do |f| %>
+<%= form_for @product, html: {multipart: true} do |f| %>
   <% if @product.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@product.errors.count, "error") %> prohibited this product from being saved:</h2>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -27,6 +27,10 @@
     <%= f.label :price %><br>
     <%= f.text_field :price %>
   </div>
+  <div class="field">
+    <%= f.label :pdf %><br>
+    <%= f.file_field :pdf %>
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -14,7 +14,9 @@
   <strong>Image url:</strong>
   <%= @product.image_file_name %>
 </p>
-
+<p>
+  <%= link_to "Download Product Data PDF", @product.pdf.url(:original, false) %>
+</p>
 <p>
   <strong>Price:</strong>
   <%= @product.price %>


### PR DESCRIPTION
Allows any user (needs to later be restricted to admin) to upload a *.pdf file associated with a product. Allows any user to download a PDF associated with the product on the product show page. 